### PR TITLE
Use httpredir.debian.org instead of cdn.debian.net and http.debian.ne…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,11 +17,11 @@
 # limitations under the License.
 #
 
-default['aptstd']['mirror_main'] = "http://cdn.debian.net/debian"
+default['aptstd']['mirror_main'] = "http://httpredir.debian.org/debian"
 default['aptstd']['mirror_archive'] = "http://archive.debian.org/debian"
 default['aptstd']['mirror_security'] = "http://security.debian.org/"
 default['aptstd']['mirror_backports'] = "http://backports.debian.org/debian-backports"
-default['aptstd']['mirror_lts'] = "http://http.debian.net/debian/"
+default['aptstd']['mirror_lts'] = "http://httpredir.debian.org/debian/"
 default['aptstd']['components'] = ['main', 'contrib', 'non-free']
 default['aptstd']['use_security'] = true
 default['aptstd']['use_updates'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,6 @@ maintainer_email "devops@asmirnov.info"
 license          "Apache 2.0"
 description      "Configures apt for standard repositories"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.3"
+version          "0.2.4"
 
 depends          "apt"


### PR DESCRIPTION
…t. Now it's recommended method https://lists.debian.org/debian-devel-announce/2015/05/msg00003.html